### PR TITLE
Updated wrong license classifier for `setup.py`.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
 
     classifiers=[
         'Development Status :: 4 - Beta',
-        'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
+        'License :: OSI Approved :: MIT License,
         'Programming Language :: Python :: 3',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
 
     classifiers=[
         'Development Status :: 4 - Beta',
-        'License :: OSI Approved :: MIT License,
+        'License :: OSI Approved :: MIT License',
         'Programming Language :: Python :: 3',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],


### PR DESCRIPTION
The project is licensed under the MIT License. 
The wrong classifier of GPLv3 is misleading (and honestly, terrifying) people.